### PR TITLE
Remove recovered material stub processes from LCI builder

### DIFF
--- a/code_folder/helpers/brightway_helpers.py
+++ b/code_folder/helpers/brightway_helpers.py
@@ -1,33 +1,9 @@
-from typing import Optional, List
-from .constants import SingleLCI
 import uuid
+from typing import Optional
 from .constants import ExternalDatabase, DATABASE_NAME
 import bw2data as bd
 
 class BrightwayHelpers:
-    @staticmethod
-    def get_existing_process_id_by_name(lcis: List[SingleLCI], name: str) -> Optional[str]:
-        """Return process UUID if a process with given name exists in any LCI, else None."""
-        normalized_name = name.strip().lower()
-
-        for lci in lcis:
-            for (db_name, process_id), process_data in lci.lci_dict.items():
-                if process_data["name"].strip().lower() == normalized_name:
-                    return process_id  # This is the UUID you want
-        return None
-    
-    @staticmethod
-    def build_technosphere_exchange(name: str, process_id: str, amount: float):
-        """Create a technosphere exchange pointing to a process in our database."""
-        return {
-            "input": (DATABASE_NAME, process_id),
-            "name": name,
-            "amount": amount,
-            "unit": "kilogram",
-            "type": "technosphere",
-            "location": "RER"
-        }
-    
     @staticmethod
     def build_base_process(name: str, is_waste: Optional[bool] = False):
         """Create a minimal Brightway process with a production exchange.

--- a/code_folder/helpers/constants.py
+++ b/code_folder/helpers/constants.py
@@ -89,7 +89,7 @@ class SingleLCI:
     
     lci_dict: dict # lci for the impacts of the recycling process
     main_activity_flow_name: str # name of the recycled material inflow to the lci_dict
-    avoided_impacts_flow_name: str # LCI name of the recovered materials process
+    avoided_impacts_flow_name: str # LCI name of the avoided impacts activity
     total_inflow_amount: int #total amount of recycled material, (we need to multiply the impacts with this, to get total impact)
 
 @dataclass


### PR DESCRIPTION
## Summary
- stop creating recovered-material placeholder activities and remove the corresponding main-process exchanges
- drop the unused Brightway helper utilities and refresh the avoided-impacts doc comment

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69134399e6dc8321b1583ffdb05863c0)