### PR TITLE
Handle ecoinvent reference products in lookups

### DIFF
--- a/code_folder/build_lca.py
+++ b/code_folder/build_lca.py
@@ -18,12 +18,18 @@ from code_folder.helpers.constants import Product, Route, Scenario, Location, PR
 def main():
     bd.projects.set_current(PROJECT_NAME)
 
-    database_name = "batt2"
-    PRODUCT_SELECTION = [Product.BattZn, Product.battLiNMC111, Product.battLiCO_subsub, Product.battLiFP_subsub, Product.battLiNMC811,Product.battLiMO_subsub, Product.battLiNCA_subsub,Product.BattNiCd, Product.BattNiMH, Product.BattPb]
-    ROUTE_SELECTION = [Route.BATT_ZnAlkaliSorted, Route.BATT_EVInspectedReuse, Route.BATT_LeadAcidSorted, Route.BATT_NiCdSorted, Route.BATT_NiMHSorted, Route.DIRECT, Route.PYRO_HYDRO, Route.HYDRO, Route.PYRO_HYDRO_PRETREATMENT]
-    YEAR_SELECTION = [2015, 2020, 2025, 2030, 2035, 2040, 2045, 2050]
-    SCENARIO_SELECTION = [Scenario.CIR, Scenario.OBS, Scenario.BAU, Scenario.REC]
-    LOCATION_SELECTION = [Location.EU27_4]
+    database_name = "batt"
+    # PRODUCT_SELECTION = [Product.battPackXEV, Product.BattZn, Product.battLiNMC111, Product.battLiCO_subsub, Product.battLiFP_subsub, Product.battLiNMC811,Product.battLiMO_subsub, Product.battLiNCA_subsub,Product.BattNiCd, Product.BattNiMH, Product.BattPb]
+    # ROUTE_SELECTION = [Route.BATT_2RM_dismantlingToSmelter, Route.BATT_ZnAlkaliSorted, Route.BATT_EVInspectedReuse, Route.BATT_LeadAcidSorted, Route.BATT_NiCdSorted, Route.BATT_NiMHSorted, Route.DIRECT, Route.PYRO_HYDRO, Route.HYDRO, Route.PYRO_HYDRO_PRETREATMENT]
+    # YEAR_SELECTION = [2040]
+    # SCENARIO_SELECTION = [Scenario.REC]
+    # LOCATION_SELECTION = [Location.EU27_4]
+
+    PRODUCT_SELECTION = []
+    ROUTE_SELECTION = []
+    YEAR_SELECTION = []
+    SCENARIO_SELECTION = []
+    LOCATION_SELECTION = []
 
     # If a previous version of the database exists, remove it completely
     if database_name in bd.databases:

--- a/code_folder/build_lca.py
+++ b/code_folder/build_lca.py
@@ -18,10 +18,10 @@ from code_folder.helpers.constants import Product, Route, Scenario, Location, PR
 def main():
     bd.projects.set_current(PROJECT_NAME)
 
-    database_name = "batt"
-    PRODUCT_SELECTION = [Product.battLiNMC111, Product.battLiCO_subsub, Product.battLiFP_subsub, Product.battLiNMC811,Product.battLiMO_subsub, Product.battLiNCA_subsub,Product.BattNiCd, Product.BattNiMH, Product.BattPb, Product.BattZn]
-    ROUTE_SELECTION = [Route.BATT_EVInspectedReuse, Route.BATT_LeadAcidSorted, Route.BATT_ZnAlkaliSorted, Route.BATT_NiCdSorted, Route.BATT_NiMHSorted, Route.DIRECT, Route.PYRO_HYDRO, Route.HYDRO, Route.PYRO_HYDRO_PRETREATMENT]
-    YEAR_SELECTION = [2010, 2015, 2020, 2025, 2030, 2035, 2040, 2045, 2050]
+    database_name = "batt2"
+    PRODUCT_SELECTION = [Product.BattZn, Product.battLiNMC111, Product.battLiCO_subsub, Product.battLiFP_subsub, Product.battLiNMC811,Product.battLiMO_subsub, Product.battLiNCA_subsub,Product.BattNiCd, Product.BattNiMH, Product.BattPb]
+    ROUTE_SELECTION = [Route.BATT_ZnAlkaliSorted, Route.BATT_EVInspectedReuse, Route.BATT_LeadAcidSorted, Route.BATT_NiCdSorted, Route.BATT_NiMHSorted, Route.DIRECT, Route.PYRO_HYDRO, Route.HYDRO, Route.PYRO_HYDRO_PRETREATMENT]
+    YEAR_SELECTION = [2015, 2020, 2025, 2030, 2035, 2040, 2045, 2050]
     SCENARIO_SELECTION = [Scenario.CIR, Scenario.OBS, Scenario.BAU, Scenario.REC]
     LOCATION_SELECTION = [Location.EU27_4]
 

--- a/code_folder/build_lca.py
+++ b/code_folder/build_lca.py
@@ -25,11 +25,11 @@ def main():
     # SCENARIO_SELECTION = [Scenario.REC]
     # LOCATION_SELECTION = [Location.EU27_4]
 
-    PRODUCT_SELECTION = []
-    ROUTE_SELECTION = []
-    YEAR_SELECTION = []
-    SCENARIO_SELECTION = []
-    LOCATION_SELECTION = []
+    PRODUCT_SELECTION = [Product.battPackXEV, Product.battLiNMC111]
+    ROUTE_SELECTION = [Route.BATT_2RM_dismantlingToSmelter, Route.HYDRO]
+    YEAR_SELECTION = [2030]
+    SCENARIO_SELECTION = [Scenario.CIR]
+    LOCATION_SELECTION = [Location.EU27_4]
 
     # If a previous version of the database exists, remove it completely
     if database_name in bd.databases:

--- a/code_folder/helpers/brightway_helpers.py
+++ b/code_folder/helpers/brightway_helpers.py
@@ -73,7 +73,7 @@ class BrightwayHelpers:
         if not matches:
             raise ValueError(f"Process not found: {name} @ {location}")
 
-        if reference_product:
+        if len(matches)>1:
             filtered = [
                 act for act in matches
                 if str(act.get("reference product", "")).strip() == reference_product.strip()

--- a/code_folder/helpers/brightway_helpers.py
+++ b/code_folder/helpers/brightway_helpers.py
@@ -74,6 +74,7 @@ class BrightwayHelpers:
             raise ValueError(f"Process not found: {name} @ {location}")
 
         if len(matches)>1:
+            print(f"Warning: Multiple processes found for {name} @ {location}. Using reference product ({reference_product}) to disambiguate.")
             filtered = [
                 act for act in matches
                 if str(act.get("reference product", "")).strip() == reference_product.strip()

--- a/code_folder/helpers/constants.py
+++ b/code_folder/helpers/constants.py
@@ -8,6 +8,7 @@ PROJECT_NAME = "premise"
 ECOINVENT_NAME = "ecoinvent-3.11-cutoff"
 SUPERSTRUCTURE_NAME = "scenario_superstructure"
 BIOSPHERE_NAME = "biosphere3"
+SCRAP_DATABASE_NAME = "scrap"
 
 class Route(Enum):
     PYRO_HYDRO = "BATT_LIBToPyro1"
@@ -69,6 +70,7 @@ BW_FORMAT_LCIS_DATA_FOLDER = DATA_FOLDER / "output_data/bw_format_lcis"
 class ExternalDatabase(Enum):
     ECOINVENT="ECOINVENT"
     BIOSPHERE="BIOSPHERE"
+    SCRAP="SCRAP"
 
 class Scenario(Enum):
     OBS="OBS"

--- a/code_folder/helpers/constants.py
+++ b/code_folder/helpers/constants.py
@@ -55,6 +55,7 @@ class Product(Enum):
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DATA_FOLDER = PROJECT_ROOT / "data"
+SCRAP_PROCESSES_FILE = PROJECT_ROOT / "data" / "input_data" / "scrap_processes.xlsx"
 
 SUPPORTED_YEARS_OBS = range(2010, 2025)
 SUPPORTED_YEARS_SCENARIO = range(2025, 2051)

--- a/code_folder/helpers/constants.py
+++ b/code_folder/helpers/constants.py
@@ -20,6 +20,7 @@ class Route(Enum):
     BATT_ZnAlkaliSorted = "BATT_ZnAlkaliSorted"
     BATT_EVInspectedReuse = "BATT_EVInspectedReuse"
     BATT_NiMHSorted = "BATT_NiMHSorted"
+    BATT_2RM_dismantlingToSmelter = "BATT_2RM_dismantlingToSmelter"
     WEEE = "WEEE"
 
 
@@ -34,6 +35,7 @@ class Product(Enum):
     battLiNMC811 = "battLiNMC811"
     battLiFP_subsub = "battLiFP_subsub"
     battLiNCA_subsub = "battLiNCA_subsub"
+    battPackXEV = "battPackXEV"	
     WEEE_Cat1 = "WEEE_Cat1"
     WEEE_Cat2 = "WEEE_Cat2"
     WEEE_Cat3 = "WEEE_Cat3"
@@ -89,7 +91,8 @@ route_lci_names = {
     Route.HYDRO: "Hydrometallurgical recycling of",
     Route.WEEE: "Dismantling and shredding of ",
     Route.DIRECT: "Direct recycling of ",
-    Route.ELV: "Dismantling and shredding of "
+    Route.ELV: "Dismantling and shredding of ",
+    Route.BATT_2RM_dismantlingToSmelter: "Dismantling and shredding of "
 }
 
 @dataclass

--- a/code_folder/helpers/lca_builder.py
+++ b/code_folder/helpers/lca_builder.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from typing import List
-from code_folder.helpers.constants import SingleLCI, SingleLCIAResult, ExternalDatabase,  Location, Scenario, Route, Product, INPUT_DATA_FOLDER, ECOINVENT_NAME, BIOSPHERE_NAME, route_lci_names, SUPPORTED_YEARS_OBS, SUPPORTED_YEARS_SCENARIO, SUPERSTRUCTURE_NAME
+from code_folder.helpers.constants import SCRAP_PROCESSES_FILE, SingleLCI, SingleLCIAResult, ExternalDatabase,  Location, Scenario, Route, Product, INPUT_DATA_FOLDER, ECOINVENT_NAME, BIOSPHERE_NAME, route_lci_names, SUPPORTED_YEARS_OBS, SUPPORTED_YEARS_SCENARIO, SUPERSTRUCTURE_NAME
 import bw2data as bd
 import bw2calc as bc
 from code_folder.helpers.brightway_helpers import BrightwayHelpers
@@ -30,6 +30,7 @@ class LCABuilder:
         self.database = bd.Database(database_name)
         self.biosphere = bd.Database(BIOSPHERE_NAME)
 
+        self.scrap_processes: List[dict] = []
         self.lcis: List[SingleLCI] = []
         self.lcia_results: List[SingleLCIAResult] = []
 
@@ -41,6 +42,8 @@ class LCABuilder:
                        location_selection=List[Location],
                        ):
         """Build LCIs for all combinations of the provided selections and write to DB."""
+        self.build_scrap_processes()
+
         for route in route_selection:
 
             for product in product_selection:
@@ -59,7 +62,7 @@ class LCABuilder:
 
         # Adds all the lci_dict together in a big dict
         big_dict = {k: v for lci in self.lcis for k, v in lci.lci_dict.items()}
-        self.database.write(big_dict)
+        self.database.write(big_dict) # add scrap processes here. 
 
     def build_lci(self, route:Route, product:Product, year: int, scenario:Scenario, location:Location):
         """Build a single LCI for a specific (route, product, year, scenario, location)."""
@@ -185,7 +188,7 @@ class LCABuilder:
         output_recovered_material_rows = lci_builder_df[
     (lci_builder_df["Flow Direction"] == "recovered") |
     (lci_builder_df["LCI Flow Type"] == "recovered")
-]
+    ]
         for _, output_reco_row in output_recovered_material_rows.iterrows():
             material_list = [m.strip() for m in output_reco_row["Materials"].split(',') if m.strip()]
             flows_list = [m.strip() for m in output_reco_row["Stock/Flow IDs"].split(',') if m.strip()]
@@ -393,3 +396,34 @@ class LCABuilder:
         unit_conversion = _parse(row.get("Weight per unit", 1.0))
         recovery_efficiency = _parse(row.get("Recovery efficiency", 1.0))
         return recovery_efficiency / unit_conversion
+
+    def build_scrap_processes(self):
+        """
+        Manually added piece of code to create (scrap) processes that can be universally used by the other processes
+        """
+        for sheet_name in pd.ExcelFile(SCRAP_PROCESSES_FILE).sheet_names:
+            activity_id, activity_dict = BrightwayHelpers.build_base_process(
+            name=sheet_name,
+            database_name=self.database_name)
+            exchanges_list = pd.read_excel(
+                SCRAP_PROCESSES_FILE,
+                sheet_name=sheet_name,
+            ).fillna("")
+            for _, row in exchanges_list.iterrows():
+                external_exchange = BrightwayHelpers.build_external_exchange(
+                    database=ExternalDatabase(row['database'].upper()),
+                    ecoinvent=self.ecoinvent,
+                    biosphere=self.biosphere,
+                    process_name = row['activity name'],
+                    location=row['location'],
+                    amount=row['amount'],
+                    unit='unknown',
+                    flow_direction=row["flow direction"],
+                    categories=tuple(map(str.strip, row["categories"].split(", "))),
+                    reference_product=row['reference product'] if row['database'] == ExternalDatabase.ECOINVENT else None,
+                )
+                self._merge_exchange(
+                activity_dict[(self.database_name, activity_id)]["exchanges"],
+                external_exchange,
+            )
+        self.scrap_processes.append(activity_dict)

--- a/code_folder/helpers/lca_builder.py
+++ b/code_folder/helpers/lca_builder.py
@@ -207,6 +207,8 @@ class LCABuilder:
             linked_process_database, linked_process_name = tuple(output_reco_row['Linked process'].split(':'))
             linked_process_database = ExternalDatabase(linked_process_database.upper())
 
+            reference_product = output_reco_row.get("LCI Flow Name", "") or None
+
             avoided_impact_exchange = BrightwayHelpers.build_external_exchange(
                 database=linked_process_database,
                 ecoinvent=self.ecoinvent,
@@ -217,6 +219,7 @@ class LCABuilder:
                 flow_direction="output",
                 categories=tuple(map(str.strip, output_reco_row["Categories"].split(", "))),
                 unit=output_reco_row["Unit"],
+                reference_product=reference_product if linked_process_database == ExternalDatabase.ECOINVENT else None,
             )
             self._merge_exchange(
                 lci_dict[(self.database_name, avoided_impacts_activity_id)]["exchanges"],
@@ -251,6 +254,8 @@ class LCABuilder:
                 amount = external_row['Amount']
             linked_process_database, linked_process_name = tuple(external_row['Linked process'].split(':'))
             linked_process_database = ExternalDatabase(linked_process_database.upper())
+
+            reference_product = external_row.get("LCI Flow Name", "") or None
             external_exchange = BrightwayHelpers.build_external_exchange(
                 database=linked_process_database,
                 ecoinvent=self.ecoinvent,
@@ -260,7 +265,8 @@ class LCABuilder:
                 amount=amount,
                 unit=external_row["Unit"],
                 flow_direction=external_row["Flow Direction"],
-                categories=tuple(map(str.strip, external_row["Categories"].split(", ")))
+                categories=tuple(map(str.strip, external_row["Categories"].split(", "))),
+                reference_product=reference_product if linked_process_database == ExternalDatabase.ECOINVENT else None,
             )
             self._merge_exchange(
                 lci_dict[(self.database_name, main_activity_id)]["exchanges"],

--- a/tests/test_brightway_helpers.py
+++ b/tests/test_brightway_helpers.py
@@ -1,0 +1,82 @@
+import sys
+from pathlib import Path
+
+import pytest
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+sys.modules.setdefault("bw2data", types.SimpleNamespace(Database=object))
+
+from code_folder.helpers.brightway_helpers import BrightwayHelpers
+from code_folder.helpers.constants import ExternalDatabase
+
+
+class DummyDatabase:
+    def __init__(self, activities, name):
+        self._activities = activities
+        self.name = name
+
+    def __iter__(self):
+        return iter(self._activities)
+
+
+def test_build_external_exchange_uses_reference_product_for_ambiguous_name_and_location():
+    ecoinvent = DummyDatabase(
+        [
+            {"name": "battery treatment", "location": "RER", "code": "act-1", "reference product": "nickel"},
+            {"name": "battery treatment", "location": "RER", "code": "act-2", "reference product": "cobalt"},
+        ],
+        name="ecoinvent-test",
+    )
+
+    exchange = BrightwayHelpers.build_external_exchange(
+        database=ExternalDatabase.ECOINVENT,
+        biosphere=DummyDatabase([], "biosphere"),
+        ecoinvent=ecoinvent,
+        process_name="battery treatment",
+        amount=1.0,
+        unit="kilogram",
+        flow_direction="input",
+        location="RER",
+        categories=("air", "urban air"),
+        reference_product="nickel",
+    )
+
+    assert exchange["input"] == (ecoinvent.name, "act-1")
+
+
+def test_find_ecoinvent_key_by_name_requires_reference_product_when_ambiguous():
+    ecoinvent = DummyDatabase(
+        [
+            {"name": "battery treatment", "location": "RER", "code": "act-1", "reference product": "nickel"},
+            {"name": "battery treatment", "location": "RER", "code": "act-2", "reference product": "cobalt"},
+        ],
+        name="ecoinvent-test",
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        BrightwayHelpers.find_ecoinvent_key_by_name(
+            name="battery treatment",
+            ecoinvent=ecoinvent,
+            location="RER",
+        )
+
+    assert "Multiple processes found" in str(excinfo.value)
+
+
+def test_find_ecoinvent_key_by_name_single_match():
+    ecoinvent = DummyDatabase(
+        [
+            {"name": "battery treatment", "location": "RER", "code": "act-1", "reference product": "nickel"},
+        ],
+        name="ecoinvent-test",
+    )
+
+    result = BrightwayHelpers.find_ecoinvent_key_by_name(
+        name="battery treatment",
+        ecoinvent=ecoinvent,
+        location="RER",
+    )
+
+    assert result == (ecoinvent.name, "act-1")


### PR DESCRIPTION
## Summary
- allow reference products to disambiguate ecoinvent activity lookups and surface clearer errors
- pass the LCI builder reference product through recovered and external exchange construction when targeting ecoinvent
- add tests covering reference-product selection and ambiguous/single-match scenarios

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920457aac68832184be7390bde173a9)