### PR TITLE
Add caching for ecoinvent and biosphere lookups

### DIFF
--- a/code_folder/helpers/brightway_helpers.py
+++ b/code_folder/helpers/brightway_helpers.py
@@ -1,9 +1,13 @@
 import uuid
+from collections import OrderedDict
 from typing import Optional
 from code_folder.helpers.constants import ExternalDatabase
 import bw2data as bd
 
 class BrightwayHelpers:
+    _ecoinvent_cache = OrderedDict()
+    _biosphere_cache = OrderedDict()
+
     @staticmethod
     def build_base_process(name: str, database_name: str, is_waste: Optional[bool] = False):
         """Create a minimal Brightway process with a production exchange.
@@ -49,17 +53,33 @@ class BrightwayHelpers:
     @staticmethod
     def find_ecoinvent_key_by_name(name, ecoinvent: bd.Database, location):
         """Find (database_name, code) for an ecoinvent activity by exact name and location."""
+        cache_key = (name.strip(), location.strip())
+        if cache_key in BrightwayHelpers._ecoinvent_cache:
+            BrightwayHelpers._ecoinvent_cache.move_to_end(cache_key)
+            return BrightwayHelpers._ecoinvent_cache[cache_key]
         for act in ecoinvent:
             if act["name"].strip() == name.strip() and act.get("location", "").strip() == location.strip():
                 # Use the actual database name and a 2-tuple key as required by Brightway
-                return (ecoinvent.name, act["code"])
+                BrightwayHelpers._ecoinvent_cache[cache_key] = (ecoinvent.name, act["code"])
+                BrightwayHelpers._ecoinvent_cache.move_to_end(cache_key)
+                if len(BrightwayHelpers._ecoinvent_cache) > 50:
+                    BrightwayHelpers._ecoinvent_cache.popitem(last=False)
+                return BrightwayHelpers._ecoinvent_cache[cache_key]
         raise ValueError(f"Process not found: {name} @ {location}")
-    
+
     @staticmethod
     def find_biosphere_key_by_name(name, biosphere: bd.Database, categories=("air", "urban air close to ground")):
         """Find (database_name, code) for a biosphere flow by exact name and categories."""
+        cache_key = (name.strip(), tuple(categories))
+        if cache_key in BrightwayHelpers._biosphere_cache:
+            BrightwayHelpers._biosphere_cache.move_to_end(cache_key)
+            return BrightwayHelpers._biosphere_cache[cache_key]
         for flow in biosphere:
             if flow["name"].strip() == name.strip() and tuple(flow["categories"]) == categories:
                 # Use the actual database name for biosphere
-                return (biosphere.name, flow["code"])
+                BrightwayHelpers._biosphere_cache[cache_key] = (biosphere.name, flow["code"])
+                BrightwayHelpers._biosphere_cache.move_to_end(cache_key)
+                if len(BrightwayHelpers._biosphere_cache) > 50:
+                    BrightwayHelpers._biosphere_cache.popitem(last=False)
+                return BrightwayHelpers._biosphere_cache[cache_key]
         raise ValueError(f"Biosphere flow not found: {name} @ {categories}")


### PR DESCRIPTION
## Summary
- add simple class-level caches for ecoinvent and biosphere lookups
- reuse cached entries before scanning the databases and cap the cache size at 50 items each

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935995346ac8321a9de446315b98990)