### PR TITLE
Add Excel export for LCIA results

### DIFF
--- a/code_folder/build_lca.py
+++ b/code_folder/build_lca.py
@@ -45,6 +45,7 @@ def main():
 
     lca_builder.run_lcia(lcia_methods=LCIA_METHODS)
     lca_builder.save_lcia_results()
+    lca_builder.export_lcia_results_to_excel(lcia_methods=LCIA_METHODS)
 
 
 if __name__ == "__main__":

--- a/code_folder/helpers/lca_builder.py
+++ b/code_folder/helpers/lca_builder.py
@@ -382,6 +382,10 @@ class LCABuilder:
         """Load the latest saved LCIA results from disk into memory."""
         self.lcia_results = StorageHelper.load_latest_lcia_results()
 
+    def export_lcia_results_to_excel(self, lcia_methods):
+        """Export the in-memory LCIA results to an Excel workbook."""
+        StorageHelper.save_lcia_results_to_excel(self.lcia_results, lcia_methods)
+
     @staticmethod
     def _merge_exchange(exchanges: List[dict], new_exchange: dict) -> None:
         """Merge an exchange into a list, summing amounts for duplicate entries."""

--- a/code_folder/helpers/storage_helper.py
+++ b/code_folder/helpers/storage_helper.py
@@ -1,10 +1,18 @@
 from datetime import datetime
 import pickle
-from code_folder.helpers.constants import LOADABLE_LCI_DATA_FOLDER, BW_FORMAT_LCIS_DATA_FOLDER, LOADABLE_LCIA_RESULTS_DATA_FOLDER
-from bw2io.export.excel import write_lci_excel
 import os
 import shutil
+
 import bw2data as bd
+import pandas as pd
+from bw2io.export.excel import write_lci_excel
+
+from code_folder.helpers.constants import (
+    BW_FORMAT_LCIS_DATA_FOLDER,
+    LCIA_RESULTS_EXCEL_FOLDER,
+    LOADABLE_LCI_DATA_FOLDER,
+    LOADABLE_LCIA_RESULTS_DATA_FOLDER,
+)
 
 class StorageHelper:
     """Utility functions for persisting and loading LCIs, LCIA results, and DB exports."""
@@ -86,3 +94,52 @@ class StorageHelper:
             lcia_results = pickle.load(f)
         print(f"✅ Loaded {len(lcia_results)} LCIA results from {file_path}")
         return lcia_results
+
+    @staticmethod
+    def save_lcia_results_to_excel(lcia_results, lcia_methods):
+        """Export LCIA results to Excel with one row per scenario/year/route/product and impact type."""
+        if not lcia_results:
+            print("⚠️ No LCIA results to export to Excel.")
+            return
+
+        os.makedirs(LCIA_RESULTS_EXCEL_FOLDER, exist_ok=True)
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        file_path = os.path.join(LCIA_RESULTS_EXCEL_FOLDER, f"lcia_results_{timestamp}.xlsx")
+
+        method_labels = [method[1] for method in lcia_methods]
+
+        rows = []
+        for result in lcia_results:
+            metadata = {
+                "Scenario": result.lci.scenario.value,
+                "Year": result.lci.year,
+                "Location": result.lci.location.value,
+                "Product": result.lci.product.value,
+                "RecyclingRoute": result.lci.route.value,
+            }
+
+            for impact_type, impacts in (
+                ("normal", result.total_impacts),
+                ("avoided", result.avoided_impacts),
+            ):
+                row = {**metadata, "Impact_type": impact_type}
+                for label in method_labels:
+                    row[label] = impacts.get(label)
+                rows.append(row)
+
+        columns = [
+            "Scenario",
+            "Year",
+            "Location",
+            "Product",
+            "RecyclingRoute",
+            "Impact_type",
+            *method_labels,
+        ]
+        df = pd.DataFrame(rows, columns=columns)
+
+        with pd.ExcelWriter(file_path, engine="xlsxwriter") as writer:
+            df.to_excel(writer, sheet_name="impact_per_kg", index=False)
+
+        print(f"✅ Saved LCIA results to Excel at {file_path}")


### PR DESCRIPTION
## Summary
- add an Excel export helper that flattens LCIA results by scenario, year, route, product, and impact type
- expose LCABuilder API for exporting LCIA results and invoke it after running LCIA
- persist outputs into timestamped workbooks under the lcia_results_excel directory

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b0b8d2c4c83219e1c5795b4cb6832)